### PR TITLE
mock1 collector - preparation for incoming specified dynamic metric

### DIFF
--- a/plugin/collector/snap-plugin-collector-mock1/mock/mock.go
+++ b/plugin/collector/snap-plugin-collector-mock1/mock/mock.go
@@ -39,24 +39,48 @@ const (
 	Type = plugin.CollectorPluginType
 )
 
-// make sure that we actually satisify requierd interface
+// make sure that we actually satisfying required interface
 var _ plugin.CollectorPlugin = (*Mock)(nil)
 
 // Mock collector implementation used for testing
 type Mock struct {
 }
 
+var availableHosts = getAllHostnames()
+
 // CollectMetrics collects metrics for testing
 func (f *Mock) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricType, error) {
 	metrics := []plugin.MetricType{}
 	rand.Seed(time.Now().UTC().UnixNano())
 	for i, p := range mts {
-		if mts[i].Namespace()[2].Value == "*" {
-			for j := 0; j < 10; j++ {
+		if isDynamic, _ := mts[i].Namespace().IsDynamic(); isDynamic {
+			requestedHosts := []string{}
+
+			if mts[i].Namespace()[2].Value == "*" {
+				// when dynamic element is not specified (equals an asterisk)
+				// then consider all available hosts as requested hosts
+				requestedHosts = append(requestedHosts, availableHosts...)
+
+			} else {
+				// when the dynamic element is specified
+				// then consider this specified host as requested hosts
+				host := mts[i].Namespace()[2].Value
+
+				// check if specified host is available in system
+				if contains(availableHosts, host) {
+					requestedHosts = append(requestedHosts, host)
+				} else {
+					return nil, fmt.Errorf("requested hostname `%s` is not available (list of available hosts: %s)", host, availableHosts)
+				}
+
+			}
+
+			// collect data for each of requested hosts
+			for _, host := range requestedHosts {
+				data := randInt(65, 90)
 				ns := make([]core.NamespaceElement, len(mts[i].Namespace()))
 				copy(ns, mts[i].Namespace())
-				ns[2].Value = fmt.Sprintf("host%d", j)
-				data := randInt(65, 90)
+				ns[2].Value = host
 				mt := plugin.MetricType{
 					Data_:      data,
 					Namespace_: ns,
@@ -65,6 +89,7 @@ func (f *Mock) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricType, err
 				}
 				metrics = append(metrics, mt)
 			}
+
 		} else {
 			if cv, ok := p.Config().Table()["test"]; ok {
 				p.Data_ = fmt.Sprintf("The mock collected data! config data: name=%s password=%s test=%v", p.Config().Table()["name"], p.Config().Table()["password"], cv.(ctypes.ConfigValueBool).Value)
@@ -78,7 +103,7 @@ func (f *Mock) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricType, err
 	return metrics, nil
 }
 
-//GetMetricTypes returns metric types for testing
+// GetMetricTypes returns metric types for testing
 func (f *Mock) GetMetricTypes(cfg plugin.ConfigType) ([]plugin.MetricType, error) {
 	mts := []plugin.MetricType{}
 	if _, ok := cfg.Table()["test-fail"]; ok {
@@ -95,7 +120,7 @@ func (f *Mock) GetMetricTypes(cfg plugin.ConfigType) ([]plugin.MetricType, error
 	return mts, nil
 }
 
-//GetConfigPolicy returns a ConfigPolicyTree for testing
+// GetConfigPolicy returns a ConfigPolicyTree for testing
 func (f *Mock) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
 	c := cpolicy.New()
 	rule, _ := cpolicy.NewStringRule("name", false, "bob")
@@ -107,7 +132,7 @@ func (f *Mock) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
 	return c, nil
 }
 
-//Meta returns meta data for testing
+// Meta returns meta data for testing
 func Meta() *plugin.PluginMeta {
 	return plugin.NewPluginMeta(
 		Name,
@@ -121,7 +146,26 @@ func Meta() *plugin.PluginMeta {
 	)
 }
 
-//Random number generator
+// contains reports whether a given item is found in a slice
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+// getAllHostnames returns all available hostnames ('host0', 'host1', ..., 'host9')
+func getAllHostnames() []string {
+	res := []string{}
+	for j := 0; j < 10; j++ {
+		res = append(res, fmt.Sprintf("host%d", j))
+	}
+	return res
+}
+
+// Random number generator
 func randInt(min int, max int) int {
 	return min + rand.Intn(max-min)
 }


### PR DESCRIPTION
This pull request is related with specifying dynamic metric and its intention is to prepare snap-plugin-collector-mock1 for incoming specified dynamic metrics to collect. 
#### Why that is needed:

**_Currently_**: the CollectMetrics() of this plugin is written in a way, that for dynamic metrics integer values are returned as a data, for the rest of metric data is a string:

![image](https://cloud.githubusercontent.com/assets/11335874/18399810/39fc6adc-76d3-11e6-877b-8338cfb2d539.png)

So, for specified dynamic metric as e.g. "/intel/mock/host0/baz" CollectMetric() should return integer data as a metric's value as well. But this "if" "else" statement (lines  [L54](https://github.com/intelsdi-x/snap/blob/master/plugin/collector/snap-plugin-collector-mock1/mock/mock.go#L54) - [L68](https://github.com/intelsdi-x/snap/blob/master/plugin/collector/snap-plugin-collector-mock1/mock/mock.go#L68)) does not allow for that.

**_After_**: this changes causes the following behaviour of CollectMetrics()

`CollectMetrics("/intel/mock/host0/baz")` returns 1 metric with integer type data
`CollectMetrics("/intel/mock/*/baz")` will returns 10 metrics with integer type data (as it is now)
`CollectMetrics("/intel/mock/foo")` will returns 1 metric with string type data (as it is now)
`CollectMetrics("/intel/mock/bar")` will returns 1 metric with string type data (as it is now)

`CollectMetrics("/intel/mock/host10/baz")` will returns nil and error (because host0, host1, up to host9 are only available)

(*) Notice, that the notation of CollectMetrics is simplify - just to show how it works
## Summary of changes:
- distinguishing between handling dynamic element which value equals "*" or specified instance e.g "host0"
- additional test cases has been added to cover that
- fixed typo
## Testing done:
- medium test
