### PR TITLE
Fixed tests in distributed task

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-#Contributing to Snap
+# Contributing to Snap
 
 Contributing to Snap is a snap (pun intended :turtle:).
 

--- a/cmd/snaptel/config.go
+++ b/cmd/snaptel/config.go
@@ -90,7 +90,7 @@ func getConfig(ctx *cli.Context) error {
 	defer w.Flush()
 	r := pClient.GetPluginConfig(ptyp, pname, strconv.Itoa(pver))
 	if r.Err != nil {
-		return fmt.Errorf("Error requesting info: ", r.Err)
+		return fmt.Errorf("Error requesting info: %v", r.Err)
 	}
 	printFields(w, false, 0,
 		"NAME",

--- a/cmd/snaptel/config.go
+++ b/cmd/snaptel/config.go
@@ -84,7 +84,7 @@ func getConfig(ctx *cli.Context) error {
 		return newUsageError("Must provide plugin name", ctx)
 	}
 	if pver < 1 {
-		return newUsageError("Must provide plugin version", ctx)
+		return newUsageError("Plugin version must be greater than zero", ctx)
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
 	defer w.Flush()

--- a/cmd/snaptel/main.go
+++ b/cmd/snaptel/main.go
@@ -45,7 +45,7 @@ type usageError struct {
 }
 
 func (ue usageError) Error() string {
-	return ue.s
+	return fmt.Sprintf("Error: %s \nUsage: %s", ue.s, ue.ctx.Command.Usage)
 }
 
 func (ue usageError) help() {

--- a/cmd/snaptel/metric.go
+++ b/cmd/snaptel/metric.go
@@ -158,7 +158,7 @@ func printMetric(metric *client.GetMetricResult, idx int) error {
 
 func getMetric(ctx *cli.Context) error {
 	if !ctx.IsSet("metric-namespace") {
-		return newUsageError("namespace is required\n\n", ctx)
+		return newUsageError("Must provide metric namespace", ctx)
 	}
 	ns := ctx.String("metric-namespace")
 	ver := ctx.Int("metric-version")

--- a/cmd/snaptel/plugin.go
+++ b/cmd/snaptel/plugin.go
@@ -35,7 +35,7 @@ func loadPlugin(ctx *cli.Context) error {
 	pAsc := ctx.String("plugin-asc")
 	var paths []string
 	if len(ctx.Args()) != 1 {
-		return newUsageError("Incorrect usage:", ctx)
+		return newUsageError("Incorrect usage", ctx)
 	}
 	paths = append(paths, ctx.Args().First())
 	if pAsc != "" {
@@ -104,7 +104,7 @@ func swapPlugins(ctx *cli.Context) error {
 	pAsc := ctx.String("plugin-asc")
 	var paths []string
 	if len(ctx.Args()) < 1 || len(ctx.Args()) > 2 {
-		return newUsageError("Incorrect usage:", ctx)
+		return newUsageError("Incorrect usage", ctx)
 	}
 	paths = append(paths, ctx.Args().First())
 	if pAsc != "" {

--- a/cmd/snaptel/plugin.go
+++ b/cmd/snaptel/plugin.go
@@ -66,7 +66,7 @@ func loadPlugin(ctx *cli.Context) error {
 func unloadPlugin(ctx *cli.Context) error {
 	pType := ctx.Args().Get(0)
 	pName := ctx.Args().Get(1)
-	pVer, err := strconv.Atoi(ctx.Args().Get(2))
+	pVerStr := ctx.Args().Get(2)
 
 	if pType == "" {
 		return newUsageError("Must provide plugin type", ctx)
@@ -74,11 +74,16 @@ func unloadPlugin(ctx *cli.Context) error {
 	if pName == "" {
 		return newUsageError("Must provide plugin name", ctx)
 	}
+	if pVerStr == "" {
+		return newUsageError("Must provide plugin version", ctx)
+	}
+
+	pVer, err := strconv.Atoi(pVerStr)
 	if err != nil {
 		return newUsageError("Can't convert version string to integer", ctx)
 	}
 	if pVer < 1 {
-		return newUsageError("Must provide plugin version", ctx)
+		return newUsageError("Plugin version must be greater than zero", ctx)
 	}
 
 	r := pClient.UnloadPlugin(pType, pName, pVer)
@@ -139,7 +144,7 @@ func swapPlugins(ctx *cli.Context) error {
 		return newUsageError("Must provide plugin name", ctx)
 	}
 	if pVer < 1 {
-		return newUsageError("Must provide plugin version", ctx)
+		return newUsageError("Plugin version must be greater than zero", ctx)
 	}
 
 	r := pClient.SwapPlugin(paths, pType, pName, pVer)

--- a/cmd/snaptel/tribe.go
+++ b/cmd/snaptel/tribe.go
@@ -55,7 +55,7 @@ func listMembers(ctx *cli.Context) error {
 
 func showMember(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
-		return newUsageError("Incorrect usage:", ctx)
+		return newUsageError("Incorrect usage", ctx)
 	}
 
 	resp := pClient.GetMember(ctx.Args().First())
@@ -105,7 +105,7 @@ func listAgreements(ctx *cli.Context) error {
 
 func createAgreement(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
-		return newUsageError("Incorrect usage:", ctx)
+		return newUsageError("Incorrect usage", ctx)
 	}
 
 	resp := pClient.AddAgreement(ctx.Args().First())
@@ -118,7 +118,7 @@ func createAgreement(ctx *cli.Context) error {
 
 func deleteAgreement(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
-		return newUsageError("Incorrect usage:", ctx)
+		return newUsageError("Incorrect usage", ctx)
 	}
 
 	resp := pClient.DeleteAgreement(ctx.Args().First())
@@ -131,7 +131,7 @@ func deleteAgreement(ctx *cli.Context) error {
 
 func joinAgreement(ctx *cli.Context) error {
 	if len(ctx.Args()) != 2 {
-		return newUsageError("Incorrect usage:", ctx)
+		return newUsageError("Incorrect usage", ctx)
 	}
 
 	resp := pClient.JoinAgreement(ctx.Args().First(), ctx.Args().Get(1))
@@ -144,7 +144,7 @@ func joinAgreement(ctx *cli.Context) error {
 
 func leaveAgreement(ctx *cli.Context) error {
 	if len(ctx.Args()) != 2 {
-		return newUsageError("Incorrect usage:", ctx)
+		return newUsageError("Incorrect usage", ctx)
 	}
 
 	resp := pClient.LeaveAgreement(ctx.Args().First(), ctx.Args().Get(1))
@@ -157,7 +157,7 @@ func leaveAgreement(ctx *cli.Context) error {
 
 func agreementMembers(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
-		return newUsageError("Incorrect usage:", ctx)
+		return newUsageError("Incorrect usage", ctx)
 	}
 
 	resp := pClient.GetAgreement(ctx.Args().First())

--- a/core/scheduler_event/scheduler_event.go
+++ b/core/scheduler_event/scheduler_event.go
@@ -24,6 +24,7 @@ import (
 )
 
 const (
+	PluginsUnsubscribed    = "Scheduler.PluginUnsubscribed"
 	TaskCreated            = "Scheduler.TaskCreated"
 	TaskDeleted            = "Scheduler.TaskDeleted"
 	TaskStarted            = "Scheduler.TaskStarted"
@@ -33,6 +34,15 @@ const (
 	MetricCollected        = "Scheduler.MetricsCollected"
 	MetricCollectionFailed = "Scheduler.MetricCollectionFailed"
 )
+
+type PluginsUnsubscribedEvent struct {
+	TaskID  string
+	Plugins []core.SubscribedPlugin
+}
+
+func (e PluginsUnsubscribedEvent) Namespace() string {
+	return PluginsUnsubscribed
+}
 
 type TaskStartedEvent struct {
 	TaskID string

--- a/docs/SNAPTELD.md
+++ b/docs/SNAPTELD.md
@@ -79,20 +79,20 @@ By default, Snap daemon loads the configuration in `/etc/snap/snapteld.conf` and
 
 * shutdown `snap-telemetry` service and ensure there's no Snap processes running:
     RedHat 6/Ubuntu 14.04:
-    ```
+```
 $ sevice snap-telemetry stop
 $ pgrep snap
-    ```
+```
     RedHat 7/Ubuntu 16.04:
-    ```
+```
 $ systemctl stop snap-telemetry
 $ pgrep snap
-    ```
+```
 
 * run Snap with debug log `--log-level 1`, no log file `--log-path ''`, along with any other custom startup options (it will use the snapteld.conf file settings if an option is omitted):
-    ```
+```
 $ snapteld --log-level 1 --log-path '' --plugin-trust 0
-    ```
+```
 
 This should result in the following log output:
 ```

--- a/docs/SNAPTELD_CONFIGURATION.md
+++ b/docs/SNAPTELD_CONFIGURATION.md
@@ -72,7 +72,7 @@ The control section contains settings for configuring the Control module within 
 ```yaml
 control:
   # auto_discover_path sets the directory(s) to auto load plugins and tasks on
-  # the start of the snap daemon. This can be a comma separated list of directories.
+  # the start of the snap daemon. This can be a colon separated list of directories.
   auto_discover_path: /opt/snap/plugins:/opt/snap/tasks
 
   # cache_expiration sets the time interval for the plugin cache to use before

--- a/examples/configs/snap-config-sample.yaml
+++ b/examples/configs/snap-config-sample.yaml
@@ -28,7 +28,7 @@ gomaxprocs: 2
 # control module of snapteld.
 control:
   # auto_discover_path sets the directory(s) to auto load plugins and tasks on
-  # the start of the snap daemon. This can be a comma separated list of directories.
+  # the start of the snap daemon. This can be a colon separated list of directories.
   auto_discover_path: /opt/snap/plugins:/opt/snap/tasks
 
   # cache_expiration sets the time interval for the plugin cache to use before

--- a/pkg/schedule/windowed_schedule_medium_test.go
+++ b/pkg/schedule/windowed_schedule_medium_test.go
@@ -330,7 +330,7 @@ func TestWindowedSchedule(t *testing.T) {
 	}) // the end of `Nominal windowed Schedule`
 
 	Convey("Windowed Schedule with determined the count of runs", t, func() {
-		interval := time.Millisecond * 10
+		interval := time.Second
 
 		Convey("expected to start immediately", func() {
 			Convey("single run", func() {
@@ -523,8 +523,6 @@ func TestWindowedSchedule(t *testing.T) {
 		Convey("started in the past", func() {
 			startWait := time.Millisecond * -200
 			count := uint(1)
-			interval := time.Millisecond * 10
-
 			start := time.Now().Add(startWait)
 			w := NewWindowedSchedule(
 				interval,
@@ -564,7 +562,6 @@ func TestWindowedSchedule(t *testing.T) {
 		Convey("with determined stop", func() {
 			startWait := time.Millisecond * 50
 			windowSize := time.Millisecond * 200
-			interval := time.Millisecond * 10
 			count := uint(1)
 
 			start := time.Now().Add(startWait)

--- a/scheduler/fixtures/fixtures.go
+++ b/scheduler/fixtures/fixtures.go
@@ -25,19 +25,23 @@ import "github.com/intelsdi-x/gomit"
 import "github.com/intelsdi-x/snap/core/scheduler_event"
 
 type listenToSchedulerEvent struct {
-	Ended chan struct{}
+	Ended                    chan struct{}
+	UnsubscribedPluginEvents chan *scheduler_event.PluginsUnsubscribedEvent
 }
 
 // NewListenToSchedulerEvent
 func NewListenToSchedulerEvent() *listenToSchedulerEvent {
 	return &listenToSchedulerEvent{
 		Ended: make(chan struct{}),
+		UnsubscribedPluginEvents: make(chan *scheduler_event.PluginsUnsubscribedEvent),
 	}
 }
 
 func (l *listenToSchedulerEvent) HandleGomitEvent(e gomit.Event) {
-	switch e.Body.(type) {
+	switch msg := e.Body.(type) {
 	case *scheduler_event.TaskEndedEvent:
 		l.Ended <- struct{}{}
+	case *scheduler_event.PluginsUnsubscribedEvent:
+		l.UnsubscribedPluginEvents <- msg
 	}
 }

--- a/scheduler/managers.go
+++ b/scheduler/managers.go
@@ -53,7 +53,7 @@ func (m *managers) Add(key string, val managesMetrics) {
 
 // Returns the managesMetric instance that maps to given
 // string. If an empty string is given, will instead return
-// the local instance passed in on initializiation.
+// the local instance passed in on initialization.
 func (m *managers) Get(key string) (managesMetrics, error) {
 	if key == "" {
 		return m.local, nil

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -777,6 +777,13 @@ func (s *scheduler) HandleGomitEvent(e gomit.Event) {
 		task, _ := s.getTask(v.TaskID)
 		task.UnsubscribePlugins()
 		s.taskWatcherColl.handleTaskDisabled(v.TaskID, v.Why)
+	case *scheduler_event.PluginsUnsubscribedEvent:
+		log.WithFields(log.Fields{
+			"_module":         "scheduler-events",
+			"_block":          "handle-events",
+			"event-namespace": e.Namespace(),
+			"task-id":         v.TaskID,
+		}).Debug("event received")
 	default:
 		log.WithFields(log.Fields{
 			"_module":         "scheduler-events",

--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -366,6 +366,11 @@ func (t *task) UnsubscribePlugins() []serror.SnapError {
 	depGroups := getWorkflowPlugins(t.workflow.processNodes, t.workflow.publishNodes, t.workflow.metrics)
 	var errs []serror.SnapError
 	for k := range depGroups {
+		event := scheduler_event.PluginsUnsubscribedEvent{
+			TaskID:  t.ID(),
+			Plugins: depGroups[k].subscribedPlugins,
+		}
+		defer t.eventEmitter.Emit(event)
 		mgr, err := t.RemoteManagers.Get(k)
 		if err != nil {
 			errs = append(errs, serror.New(err))

--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -275,8 +275,17 @@ func (t *task) stream() {
 			t.maxMetricsBuffer)
 		if err != nil {
 			consecutiveFailures++
-			e := checkTaskFailures(t, consecutiveFailures)
-			if e != nil {
+			// check task failures
+			if t.stopOnFailure >= 0 && consecutiveFailures >= t.stopOnFailure {
+				taskLogger.WithFields(log.Fields{
+					"_block":               "stream",
+					"task-id":              t.id,
+					"task-name":            t.name,
+					"consecutive failures": consecutiveFailures,
+					"error":                t.lastFailureMessage,
+				}).Error(ErrTaskDisabledOnFailures)
+				// disable the task
+				t.disable(t.lastFailureMessage)
 				return
 			}
 			// If we are unsuccessful at setting up the stream
@@ -321,8 +330,17 @@ func (t *task) stream() {
 					time.Sleep(resetTime)
 					done = true
 				}
-				e := checkTaskFailures(t, consecutiveFailures)
-				if e != nil {
+				// check task failures
+				if t.stopOnFailure >= 0 && consecutiveFailures >= t.stopOnFailure {
+					taskLogger.WithFields(log.Fields{
+						"_block":               "stream",
+						"task-id":              t.id,
+						"task-name":            t.name,
+						"consecutive failures": consecutiveFailures,
+						"error":                t.lastFailureMessage,
+					}).Error(ErrTaskDisabledOnFailures)
+					// disable the task
+					t.disable(t.lastFailureMessage)
 					return
 				}
 			}
@@ -330,28 +348,6 @@ func (t *task) stream() {
 	}
 }
 
-func checkTaskFailures(t *task, consecutiveFailures int) error {
-	if t.stopOnFailure >= 0 && consecutiveFailures >= t.stopOnFailure {
-		taskLogger.WithFields(log.Fields{
-			"_block":               "spin",
-			"task-id":              t.id,
-			"task-name":            t.name,
-			"consecutive failures": consecutiveFailures,
-			"error":                t.lastFailureMessage,
-		}).Error(ErrTaskDisabledOnFailures)
-		// You must lock on state change for tasks
-		t.Lock()
-		t.state = core.TaskDisabled
-		t.Unlock()
-		// Send task disabled event
-		event := new(scheduler_event.TaskDisabledEvent)
-		event.TaskID = t.id
-		event.Why = fmt.Sprintf("Task disabled with error: %s", t.lastFailureMessage)
-		defer t.eventEmitter.Emit(event)
-		return ErrTaskDisabledOnFailures
-	}
-	return nil
-}
 func (t *task) Stop() {
 	t.Lock()
 	defer t.Unlock()
@@ -366,7 +362,7 @@ func (t *task) UnsubscribePlugins() []serror.SnapError {
 	depGroups := getWorkflowPlugins(t.workflow.processNodes, t.workflow.publishNodes, t.workflow.metrics)
 	var errs []serror.SnapError
 	for k := range depGroups {
-		event := scheduler_event.PluginsUnsubscribedEvent{
+		event := &scheduler_event.PluginsUnsubscribedEvent{
 			TaskID:  t.ID(),
 			Plugins: depGroups[k].subscribedPlugins,
 		}
@@ -380,6 +376,14 @@ func (t *task) UnsubscribePlugins() []serror.SnapError {
 				errs = append(errs, uerrs...)
 			}
 		}
+	}
+	for _, err := range errs {
+		taskLogger.WithFields(log.Fields{
+			"_block":     "UnsubscribePlugins",
+			"task-id":    t.id,
+			"task-name":  t.name,
+			"task-state": t.state,
+		}).Error(err)
 	}
 	return errs
 }
@@ -489,15 +493,9 @@ func (t *task) spin() {
 						"consecutive failures": consecutiveFailures,
 						"error":                t.lastFailureMessage,
 					}).Error(ErrTaskDisabledOnFailures)
-					// You must lock on state change for tasks
-					t.Lock()
-					t.state = core.TaskDisabled
-					t.Unlock()
-					// Send task disabled event
-					event := new(scheduler_event.TaskDisabledEvent)
-					event.TaskID = t.id
-					event.Why = fmt.Sprintf("Task disabled with error: %s", t.lastFailureMessage)
-					defer t.eventEmitter.Emit(event)
+
+					// disable the task
+					t.disable(t.lastFailureMessage)
 					return
 				}
 
@@ -515,10 +513,9 @@ func (t *task) spin() {
 
 			// Schedule has errored
 			case schedule.Error:
-				// You must lock task to change state
-				t.Lock()
-				t.state = core.TaskDisabled
-				t.Unlock()
+				// disable the task
+				failureMessage := sr.Error().Error()
+				t.disable(failureMessage)
 				return //spin
 
 			}
@@ -540,6 +537,19 @@ func (t *task) fire() {
 	t.state = core.TaskFiring
 	t.workflow.Start(t)
 	t.state = core.TaskSpinning
+}
+
+// disable proceeds disabling a task which consists of changing task state to disabled and emitting an appropriate event
+func (t *task) disable(failureMsg string) {
+	t.Lock()
+	t.state = core.TaskDisabled
+	t.Unlock()
+
+	// Send task disabled event
+	event := new(scheduler_event.TaskDisabledEvent)
+	event.TaskID = t.id
+	event.Why = fmt.Sprintf("Task disabled with error: %s", failureMsg)
+	defer t.eventEmitter.Emit(event)
 }
 
 func (t *task) waitForSchedule() {


### PR DESCRIPTION
Fixes the following failures:

![image](https://cloud.githubusercontent.com/assets/11335874/24364177/3a60246a-1312-11e7-9613-dc1ac4aac9f9.png)


### Summary of changes:
- unsubscribe plugins before emitting of TaskEnded(or TaskDisabled) event

Before  |  After
-------- |---------
change state to core.TaskEnded |   change state to core.TaskEnded
emit TaskEndedEvent  |   unsubscribePlugins
unsubscribePlugins  |  emit TaskEndedEvent

Testing done:
- still in progress

@intelsdi-x/snap-maintainers
